### PR TITLE
Fix sudo permissions for apt-get commands in WSL

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -59,15 +59,16 @@ case "$ACTION" in
         brew install readline sqlite3 xz tcl-tk@8 libb2 zstd zlib pkgconfig
         ;;
       "Linux")
-        sudo -v
-        apt-get update
-        apt-get install -y stow fd-find fzf curl feh xclip openssl
-        # Python build dependencies - pyenv
-        # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
-        apt-get install -y make build-essential libssl-dev zlib1g-dev \
-            libbz2-dev libreadline-dev libsqlite3-dev \
-            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
-            libffi-dev liblzma-dev
+        sudo bash -c '
+          apt-get update
+          apt-get install -y stow fd-find fzf curl feh xclip openssl
+          # Python build dependencies - pyenv
+          # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+          apt-get install -y make build-essential libssl-dev zlib1g-dev \
+              libbz2-dev libreadline-dev libsqlite3-dev \
+              libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
+              libffi-dev liblzma-dev
+        '
         # Install starship
         curl -fsSL https://starship.rs/install.sh | sh -s -- --yes
         # Install navi


### PR DESCRIPTION
Wrap all apt-get commands in a single sudo bash block to avoid permission errors. This prompts for password once and runs all package installations with elevated privileges.